### PR TITLE
Geth 1.13.10 // Prysm 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Overall flow of the guide is as follows:
 - Importing Validator Keystore(s) from depreciated Validator **only if re-creating a defunct or otherwise offline validator**
 - Appendices covering updates, pruning, MEV-boost, exiting
 - Emergency Action Plans
-- Monitoring with for use of Grafana locally
+- Monitoring with use of Grafana locally
 
 In addition to hardware as described in the next step, you should have a printed copy of the [Variables](.imgs/variables.xlsx) document, which will be used frequently to keep track of information that should **never be stored electronically or otherwise shared**.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This guide assumes use of MacOS on the connected device (LAN). While anyone can 
 ## Table of Contents
 
 0. [Validator Readme](./README.md)
-   - Background Information, Disclaimers
+   - Background Information
+   - Disclaimers
 1. [Validator SOP Part 1: Hardware, Software, & Deposit Setup](./validator-sop-part1-setup.md)
    - Purchase Equipment and Assemble NUC
    - Generate Staking Data
@@ -79,9 +80,9 @@ Overall flow of the guide is as follows:
 - Set up the Prysm Consensus Client and sync with other Beacon Nodes
 - Deposit 32 ETH to activate the staking Validator(s) **only if setting up a new validator**
 - Importing Validator Keystore(s) from depreciated Validator **only if re-creating a defunct or otherwise offline validator**
-- Appendices covering updates, pruning, exiting
-- Emergency Action Plans that cover the cases described above
-- Monitoring instructions for use of Grafana locally
+- Appendices covering updates, pruning, MEV-boost, exiting
+- Emergency Action Plans
+- Monitoring with for use of Grafana locally
 
 In addition to hardware as described in the next step, you should have a printed copy of the [Variables](.imgs/variables.xlsx) document, which will be used frequently to keep track of information that should **never be stored electronically or otherwise shared**.
 

--- a/validator-sop-part1-setup.md
+++ b/validator-sop-part1-setup.md
@@ -13,7 +13,7 @@
 - [Step 4 Configure Port Forwarding](#step-4-configure-port-forwarding)
 - [Step 5 Configure Timekeeping](#step-5-configure-timekeeping)
 - [Step 6 Generate Client Auth Secret](#step-6-generate-client-auth-secret)
-- [Step 7 Configure Geth](#step-7-configure-geth)
+- [Step 7 Install Geth](#step-7-install-geth)
 - [Step 8 Install Prysm](#step-8-install-prysm)
 - [Step 9 Configure the Beacon Node Service](#step-9-configure-the-beacon-node-service)
 - [Step 10 Configure the Validator Service](#step-10-configure-the-validator-service)
@@ -345,22 +345,22 @@ sudo nano /var/lib/jwtsecret/jwt.hex
 
 Press CTRL+X to exit
 
-### Step 7 Configure Geth
+### Step 7 Install Geth
 
-Time to install Geth! All commands provided below are based on the 1.13.8 version of Geth (current as of 12.22.23), but should be adjusted based on whatever the latest version of Geth is [here](https://geth.ethereum.org/downloads) - simply right click and copy the URL on the 'FOR LINUX' box. Note that MANY commands below will need to update if this version is updated.
+Time to install Geth! All commands provided below are based on the 1.13.10 version of Geth (current as of 1.11.24), but should be adjusted based on whatever the latest version of Geth is [here](https://geth.ethereum.org/downloads) - simply right click and copy the URL on the 'FOR LINUX' box. Note that MANY commands below will need to update if this version is updated.
 
 Curl the Geth build from the above link:
 
 ```console
 cd ~
-curl -LO https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.8-b20b4a71.tar.gz
+curl -LO https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
 ```
 
 Extract the files from the archive and copy to the /usr/local/bin directory. The Geth service will run it from there. Modify the file name to match the downloaded version:
 
 ```console
-tar xvf geth-linux-amd64-1.13.8-b20b4a71.tar.gz
-cd geth-linux-amd64-1.13.8-b20b4a71
+tar xvf geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
+cd geth-linux-amd64-1.13.10-bc0be1b1
 sudo cp geth /usr/local/bin
 ```
 
@@ -368,8 +368,8 @@ Clean up the files. Modify the file name to match the downloaded version:
 
 ```console
 cd ~
-rm geth-linux-amd64-1.13.8-b20b4a71.tar.gz
-rm -r geth-linux-amd64-1.13.8-b20b4a71
+rm geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
+rm -r geth-linux-amd64-1.13.10-bc0be1b1
 ```
 
 Geth will be configured to run as a background service. Create an account for the service to run under. This type of account can’t log into the server:
@@ -480,22 +480,22 @@ After running Geth for ~10 or so minutes, check the peer count to ensure it's gr
 
 The Prysm Consensus Client is made up of two binaries that provide the functionality of the beacon node and validator, respectively. This step will download and prepare the Prysm binaries.
 
-Time to install Prysm! All commands provided below are based on the 4.1.1 version of Prysm (current as of 12.15.23), but should be adjusted based on whatever the latest version of Prysm is [here](https://github.com/prysmaticlabs/prysm/releases). Note that many commands below will need to update if this version is updated.
+Time to install Prysm! All commands provided below are based on the 4.2.0 version of Prysm (current as of 1.11.24), but should be adjusted based on whatever the latest version of Prysm is [here](https://github.com/prysmaticlabs/prysm/releases). Note that many commands below will need to update if this version is updated.
 
 In the Assets section (expand if necessary) copy the download links to the beacon-chain-v…-linux-amd64 file and the validator-v…-linux-amd64 file. Be sure to copy the correct links.
 Download the binaries using the commands below. Modify the URL to match the copied download links:
 
 ```console
 cd ~
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.1.1/beacon-chain-v4.1.1-linux-amd64
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.1.1/validator-v4.1.1-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/validator-v4.2.0-linux-amd64
 ```
 
 Now, let's rename the files and make them executable and copy them to the /usr/local/bin directory. The Prysm services will run them from there. Modify the file names to match the downloaded version:
 
 ```console
-mv beacon-chain-v4.1.1-linux-amd64 beacon-chain
-mv validator-v4.1.1-linux-amd64 validator
+mv beacon-chain-v4.2.0-linux-amd64 beacon-chain
+mv validator-v4.2.0-linux-amd64 validator
 ```
 
 ```console

--- a/validator-sop-part2-upkeep.md
+++ b/validator-sop-part2-upkeep.md
@@ -33,11 +33,11 @@ It is not irregular for your Node to prompt you to restart it after some particu
 
 ### Appendix B Updating Geth
 
-First, go to the Geth Repository [here](https://geth.ethereum.org/downloads/) and right-click on the Geth for Linux button and then click copy link. Be sure to copy the correct link. It should look something like `https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.8-b20b4a71.tar.gz`. Modify the URL in the instructions below to match the download link for the latest version (x5), which is v1.13.8 in this example (current as of 12.22.23).
+First, go to the Geth Repository [here](https://geth.ethereum.org/downloads/) and right-click on the Geth for Linux button and then click copy link. Be sure to copy the correct link. It should look something like `https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.10-bc0be1b1.tar.gz`. Modify the URL in the instructions below to match the download link for the latest version (x5), which is v1.13.10 in this example (current as of 1.11.24).
 
 ```console
 cd ~
-curl -LO https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.8-b20b4a71.tar.gz
+curl -LO https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
 ```
 
 Then stop the Geth service
@@ -51,8 +51,8 @@ Note that stopping Geth always takes a moment and is not expected to complete im
 Now extract the files from the archive and copy to the /usr/local/bin directory. Modify the file name to match the downloaded version:
 
 ```console
-tar xvf geth-linux-amd64-1.13.8-b20b4a71.tar.gz
-cd geth-linux-amd64-1.13.8-b20b4a71
+tar xvf geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
+cd geth-linux-amd64-1.13.10-bc0be1b1
 sudo cp geth /usr/local/bin
 ```
 
@@ -72,8 +72,8 @@ Finally, clean up the files, modifying the file name to match the downloaded ver
 
 ```console
 cd ~
-rm geth-linux-amd64-1.13.8-b20b4a71.tar.gz
-rm -r geth-linux-amd64-1.13.8-b20b4a71
+rm geth-linux-amd64-1.13.10-bc0be1b1.tar.gz
+rm -r geth-linux-amd64-1.13.10-bc0be1b1
 geth version
 ```
 
@@ -81,15 +81,15 @@ geth version
 
 In order to update Prysm, we'll need to update both the validator and beacon-chain software.
 
-First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.1.1/beacon-chain-v4.1.1-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number (x6), which is v4.1.1 in this example (current as of 12.25.23).
+First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number (x6), which is v4.2.0 in this example (current as of 1.11.24).
 
 Curl the latest software and rename:
 
 ```console
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.1.1/validator-v4.1.1-linux-amd64
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.1.1/beacon-chain-v4.1.1-linux-amd64
-mv beacon-chain-v4.1.1-linux-amd64 beacon-chain
-mv validator-v4.1.1-linux-amd64 validator
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/validator-v4.2.0-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-linux-amd64
+mv beacon-chain-v4.2.0-linux-amd64 beacon-chain
+mv validator-v4.2.0-linux-amd64 validator
 ```
 
 Then stop the Prysm services:
@@ -133,7 +133,7 @@ journalctl --since -1hour -u prysmbeacon.service | grep version
 
 ### Appendix D Pruning Geth
 
-As of 12.25.23, Geth does **not** have online pruning capability (their 1.14 distribution should finally migrate to the path database as default, which will enable a new process, to be updated here after release).
+*As of 1.11.24, Geth does **not** have online pruning capability enabled by default (their 1.14 distribution should finally default to the path database , which will enable a new process, to be updated here after release).*
 
 You must turn Geth off before pruning, meaning that pruning time is spent offline missing attestations. Before turning off Geth as part of this process, it's recommended to go through the flow described in *Appendix F* to ensure the validator(s) are not off during sync committee duties.
 


### PR DESCRIPTION
🔄 Updated Geth and Prysm versions

Updated Geth to version 1.13.10 and Prysm to version 4.2.0, ensuring compatibility with the latest releases. The installation steps have been adjusted accordingly.

ℹ️ Note: Geth does not currently support online pruning by default, but this may change in future releases - made that extra clear
