### PR TITLE
Prysm 4.2.1

### DIFF
--- a/validator-sop-part1-setup.md
+++ b/validator-sop-part1-setup.md
@@ -480,22 +480,22 @@ After running Geth for ~10 or so minutes, check the peer count to ensure it's gr
 
 The Prysm Consensus Client is made up of two binaries that provide the functionality of the beacon node and validator, respectively. This step will download and prepare the Prysm binaries.
 
-Time to install Prysm! All commands provided below are based on the 4.2.0 version of Prysm (current as of 1.11.24), but should be adjusted based on whatever the latest version of Prysm is [here](https://github.com/prysmaticlabs/prysm/releases). Note that many commands below will need to update if this version is updated.
+Time to install Prysm! All commands provided below are based on the 4.2.1 version of Prysm (current as of 1.30.24), but should be adjusted based on whatever the latest version of Prysm is [here](https://github.com/prysmaticlabs/prysm/releases). Note that many commands below will need to update if this version is updated.
 
 In the Assets section (expand if necessary) copy the download links to the beacon-chain-v…-linux-amd64 file and the validator-v…-linux-amd64 file. Be sure to copy the correct links.
 Download the binaries using the commands below. Modify the URL to match the copied download links:
 
 ```console
 cd ~
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-linux-amd64
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/validator-v4.2.0-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/beacon-chain-v4.2.1-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/validator-v4.2.1-linux-amd64
 ```
 
 Now, let's rename the files and make them executable and copy them to the /usr/local/bin directory. The Prysm services will run them from there. Modify the file names to match the downloaded version:
 
 ```console
-mv beacon-chain-v4.2.0-linux-amd64 beacon-chain
-mv validator-v4.2.0-linux-amd64 validator
+mv beacon-chain-v4.2.1-linux-amd64 beacon-chain
+mv validator-v4.2.1-linux-amd64 validator
 ```
 
 ```console

--- a/validator-sop-part2-upkeep.md
+++ b/validator-sop-part2-upkeep.md
@@ -81,7 +81,7 @@ geth version
 
 In order to update Prysm, we'll need to update both the validator and beacon-chain software.
 
-First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/beacon-chain-v4.2.1-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number, which is v4.2.01 in this example (current as of 1.30.24).
+First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/beacon-chain-v4.2.1-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number, which is v4.2.1 in this example (current as of 1.30.24).
 
 Curl the latest software and rename:
 

--- a/validator-sop-part2-upkeep.md
+++ b/validator-sop-part2-upkeep.md
@@ -81,15 +81,15 @@ geth version
 
 In order to update Prysm, we'll need to update both the validator and beacon-chain software.
 
-First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number (x6), which is v4.2.0 in this example (current as of 1.11.24).
+First, let's check the latest version of Prysm available on their GitHub repo, which can be accessed [here](https://github.com/prysmaticlabs/prysm/releases). Be sure to copy the correct link, it should look something like `https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/beacon-chain-v4.2.1-darwin-amd64.sha256`. We will need to modify the commands below to match the latest version number, which is v4.2.01 in this example (current as of 1.30.24).
 
 Curl the latest software and rename:
 
 ```console
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/validator-v4.2.0-linux-amd64
-curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.0/beacon-chain-v4.2.0-linux-amd64
-mv beacon-chain-v4.2.0-linux-amd64 beacon-chain
-mv validator-v4.2.0-linux-amd64 validator
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/validator-v4.2.1-linux-amd64
+curl -LO https://github.com/prysmaticlabs/prysm/releases/download/v4.2.1/beacon-chain-v4.2.1-linux-amd64
+mv beacon-chain-v4.2.1-linux-amd64 beacon-chain
+mv validator-v4.2.1-linux-amd64 validator
 ```
 
 Then stop the Prysm services:


### PR DESCRIPTION
Updated the Prysm binaries to version 4.2.1, ensuring compatibility with the latest release of Prysm (1.30.24). The download links and file names were modified accordingly for both the beacon-chain and validator binaries.
